### PR TITLE
updated for django 1.9

### DIFF
--- a/templatetag_sugar/parser.py
+++ b/templatetag_sugar/parser.py
@@ -1,7 +1,7 @@
 from collections import deque
 from copy import copy
 
-from django.db.models.loading import cache
+from django.apps import apps as cache
 from django.template import TemplateSyntaxError
 
 from templatetag_sugar.node import SugarNode

--- a/templatetag_sugar/parser.py
+++ b/templatetag_sugar/parser.py
@@ -1,7 +1,10 @@
 from collections import deque
 from copy import copy
 
-from django.apps import apps as cache
+try:
+    from django.db.models.loading import cache
+except ImportError:
+    from django.apps import apps as cache
 from django.template import TemplateSyntaxError
 
 from templatetag_sugar.node import SugarNode


### PR DESCRIPTION
django.db.models.loading module was removed since 1.9
https://docs.djangoproject.com/en/1.9/internals/deprecation/
